### PR TITLE
Add GetKeysSummary Api Signature/protos

### DIFF
--- a/app/src/main/proto/vss.proto
+++ b/app/src/main/proto/vss.proto
@@ -9,7 +9,7 @@ message GetObjectRequest {
   // All APIs operate within a single store_id.
   // It is up to clients to use single or multiple stores for their use-case.
   // This can be used for client-isolation/ rate-limiting / throttling on the server-side.
-  // Authorization and billing can also be performed at the storeId level.
+  // Authorization and billing can also be performed at the store_id level.
   string store_id = 1;
 
   // Key for which the value is to be fetched.
@@ -96,6 +96,78 @@ message PutObjectRequest {
 }
 
 message PutObjectResponse {
+}
+
+message ListKeyVersionsRequest {
+
+  // store_id is a keyspace identifier.
+  // Ref: https://en.wikipedia.org/wiki/Keyspace_(distributed_data_store)
+  // All APIs operate within a single store_id.
+  // It is up to clients to use single or multiple stores for their use-case.
+  // This can be used for client-isolation/ rate-limiting / throttling on the server-side.
+  // Authorization and billing can also be performed at the store_id level.
+  string store_id = 1;
+
+  // A key_prefix is a string of characters at the beginning of the key. Prefixes can be used as
+  // a way to organize key-values in a similar way to directories.
+  //
+  // If key_prefix is specified, the response results will be limited to those keys that begin with
+  // the specified prefix.
+  //
+  // If no key_prefix is specified or it is empty (""), all the keys are eligible to be returned in
+  // the response.
+  optional string key_prefix = 2;
+
+  // page_size is used by clients to specify the maximum number of results that can be returned by
+  // the server.
+  // The server may further constrain the maximum number of results returned in a single page.
+  // If the page_size is 0 or not set, the server will decide the number of results to be returned.
+  optional int32 page_size = 3;
+
+  // page_token is a pagination token.
+  //
+  // To query for the first page of ListKeyVersions, page_token must not be specified.
+  //
+  // For subsequent pages, use the value that was returned as `next_page_token` in the previous
+  // page's ListKeyVersionsResponse.
+  optional string page_token = 4;
+}
+
+message ListKeyVersionsResponse {
+
+  // Fetched keys and versions.
+  // Even though this API reuses KeyValue struct, the value sub-field will not be set by the server.
+  repeated KeyValue key_versions = 1;
+
+  // next_page_token is a pagination token, used to retrieve the next page of results.
+  // Use this value to query for next_page of paginated ListKeyVersions operation, by specifying
+  // this value as the `page_token` in the next request.
+  //
+  // If next_page_token is empty (""), then the "last page" of results has been processed and
+  // there is no more data to be retrieved.
+  //
+  // If next_page_token is not empty, it does not necessarily mean that there is more data in the
+  // result set. The only way to know when you have reached the end of the result set is when
+  // next_page_token is empty.
+  //
+  // Caution: Clients must not assume a specific number of key_versions to be present in a page for
+  // paginated response.
+  optional string next_page_token = 2;
+
+  // global_version is a sequence-number/version of the whole store.
+  //
+  // global_version is only returned in response for the first page of the ListKeyVersionsResponse
+  // and is guaranteed to be read before reading any key-versions.
+  //
+  // In case of refreshing the complete key-version view on the client-side, correct usage for
+  // the returned global_version is as following:
+  //   1. Read global_version from the first page of paginated response and save it as local variable.
+  //   2. Update all the key_versions on client-side from all the pages of paginated response.
+  //   3. Update global_version on client_side from the local variable saved in step-1.
+  // This ensures that on client-side, all current key_versions were stored at global_version or later.
+  // This guarantee is helpful for ensuring the versioning correctness if using the global_version
+  // in PutObject API and can help avoid the race conditions related to it.
+  optional int64 global_version = 3;
 }
 
 // When HttpStatusCode is not ok (200), the response `content` contains a serialized ErrorResponse


### PR DESCRIPTION
Add GetKeysSummary Api Signature/protos

This will auto-generate required request/response objects.

This API can be used for computing version difference of keys b/w client and server-side and lazily load only necessary values.

Some notes from previous discussion on this api:
regarding "return everything with a certain key prefix" => This makes for an unbounded query on server-side hence we should be avoiding it and use pagination.

Also note that we could support storing values upto ~5MB. If we started returning value as well in this response, even a 10 item limit might mean 50MB response. So it is best to only load necessary key-values lazily depending on key-version differences.

Note regarding http/rest+protobuf protocol:
Here protobuf is only being used as a binary serialization format for request and response objects.(instead of writing custom binary serialization or json). This helps both client and server to create requests/response like class instances with ease. This payload will be used as binary body in http-rest post requests.