### PR TITLE
Add Non-conditional Put/Delete functionality

### DIFF
--- a/app/src/main/proto/vss.proto
+++ b/app/src/main/proto/vss.proto
@@ -73,18 +73,26 @@ message PutObjectRequest {
   // a database-transaction in an all-or-nothing fashion.
   // All Items in a single `PutObjectRequest` must have distinct keys.
   //
-  // Clients are expected to store a `version` against every `key`.
-  // The write will succeed if the current DB version against the `key` is the same as in the request.
-  // When initiating a `PutObjectRequest`, the request should contain their client-side version for
-  // that key-value.
+  // Key-level versioning (Conditional Write):
+  //   Clients are expected to store a `version` against every `key`.
+  //   The write will succeed if the current DB version against the `key` is the same as in the request.
+  //   When initiating a `PutObjectRequest`, the request should contain their client-side `version`
+  //   for that key-value.
   //
-  // For the first write of any key, the `version` should be '0'. If the write succeeds, the client
-  // must increment their corresponding key versions (client-side) by 1.
-  // The server increments key versions (server-side) for every successful write, hence this
-  // client-side increment is required to ensure matching versions. These updated key versions should
-  // be used in subsequent `PutObjectRequest`s for the keys.
+  //   For the first write of any `key`, the `version` should be '0'. If the write succeeds, the client
+  //   must increment their corresponding key versions (client-side) by 1.
+  //   The server increments key versions (server-side) for every successful write, hence this
+  //   client-side increment is required to ensure matching versions. These updated key versions should
+  //   be used in subsequent `PutObjectRequest`s for the keys.
   //
-  // Requests with a conflicting version will fail with `CONFLICT_EXCEPTION` as ErrorCode.
+  //   Requests with a conflicting/mismatched version will fail with `CONFLICT_EXCEPTION` as ErrorCode
+  //   for conditional writes.
+  //
+  // Skipping key-level versioning (Non-conditional Write):
+  //   If you wish to skip key-level version checks, set the `version` against the `key` to '-1'.
+  //   This will perform a non-conditional write query, after which the `version` against the `key`
+  //   is reset to '1'. Hence, the next `PutObjectRequest` for the `key` can be either
+  //   a non-conditional write or a conditional write with `version` set to `1`.
   //
   // Considerations for transactions:
   // Transaction writes of multiple items have a performance overhead, hence it is recommended to use
@@ -101,13 +109,20 @@ message PutObjectRequest {
   // Items to be deleted as a result of this `PutObjectRequest`.
   //
   // Each item in the `delete_items` field consists of a `key` and its corresponding `version`.
-  // The `version` is used to perform a version check before deleting the item.
-  // The delete will only succeed if the current database version against the `key` is the same as the `version`
-  // specified in the request.
+  //
+  // Key-Level Versioning (Conditional Delete):
+  //   The `version` is used to perform a version check before deleting the item.
+  //   The delete will only succeed if the current database version against the `key` is the same as
+  //   the `version` specified in the request.
+  //
+  // Skipping key-level versioning (Non-conditional Delete):
+  //   If you wish to skip key-level version checks, set the `version` against the `key` to '-1'.
+  //   This will perform a non-conditional delete query.
   //
   // Fails with `CONFLICT_EXCEPTION` as the ErrorCode if:
   //   * The requested item does not exist.
-  //   * The requested item does exist but there is a version-number mismatch with the one in the database.
+  //   * The requested item does exist but there is a version-number mismatch (in conditional delete)
+  //     with the one in the database.
   //
   // Multiple items in the `delete_items` field, along with the `transaction_items`, are written in a
   // database transaction in an all-or-nothing fashion.
@@ -133,8 +148,15 @@ message DeleteObjectRequest {
   // Item to be deleted as a result of this `DeleteObjectRequest`.
   //
   // An item consists of a `key` and its corresponding `version`.
-  // The item is only deleted if the current database version against the `key` is the same as the `version`
-  // specified in the request.
+  //
+  // Key-level Versioning (Conditional Delete):
+  //   The item is only deleted if the current database version against the `key` is the same as
+  //   the `version` specified in the request.
+  //
+  // Skipping key-level versioning (Non-conditional Delete):
+  //   If you wish to skip key-level version checks, set the `version` against the `key` to '-1'.
+  //   This will perform a non-conditional delete query.
+  //
   // This operation is idempotent, that is, multiple delete calls for the same item will not fail.
   //
   // If the requested item does not exist, this operation will not fail.


### PR DESCRIPTION
Similar to popular kvstores, we should also support non-conditional put/delete operations. This opens up new patterns for usage of VSS, allows clients to easily onboard to VSS (without versioning, just for remote-backups) or to just use global_version for versioning and avoid key-level version checks.


DynamoDB: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ConditionExpressions.html
If-match in cosmos: https://learn.microsoft.com/en-us/rest/api/cosmos-db/replace-a-document
