### PR TITLE
Throw NoSuchKeyException when key doesn't exist in get

### DIFF
--- a/app/src/main/java/org/vss/api/AbstractVssApi.java
+++ b/app/src/main/java/org/vss/api/AbstractVssApi.java
@@ -8,6 +8,7 @@ import org.vss.ErrorCode;
 import org.vss.ErrorResponse;
 import org.vss.KVStore;
 import org.vss.exception.ConflictException;
+import org.vss.exception.NoSuchKeyException;
 
 public abstract class AbstractVssApi {
   final KVStore kvStore;
@@ -32,6 +33,8 @@ public abstract class AbstractVssApi {
     } else if (e instanceof IllegalArgumentException
         || e instanceof InvalidProtocolBufferException) {
       errorCode = ErrorCode.INVALID_REQUEST_EXCEPTION;
+    } else if (e instanceof NoSuchKeyException) {
+      errorCode = ErrorCode.NO_SUCH_KEY_EXCEPTION;
     } else {
       errorCode = ErrorCode.INTERNAL_SERVER_EXCEPTION;
     }

--- a/app/src/main/java/org/vss/exception/NoSuchKeyException.java
+++ b/app/src/main/java/org/vss/exception/NoSuchKeyException.java
@@ -1,0 +1,7 @@
+package org.vss.exception;
+
+public class NoSuchKeyException extends RuntimeException {
+  public NoSuchKeyException(String message) {
+    super(message);
+  }
+}

--- a/app/src/main/proto/vss.proto
+++ b/app/src/main/proto/vss.proto
@@ -16,6 +16,9 @@ message GetObjectRequest {
 
   // `Key` for which the value is to be fetched.
   //
+  // If the specified `key` does not exist, returns `ErrorResponse` with `NO_SUCH_KEY_EXCEPTION` as
+  // `ErrorCode`.
+  //
   // Consistency Guarantee:
   // Get(read) operations against a `key` are consistent reads and will reflect all previous writes,
   // since Put/Write provides read-after-write and read-after-update consistency guarantees.
@@ -276,6 +279,9 @@ enum ErrorCode {
   // An internal server error occurred, client is probably at no fault and can safely retry this
   // error with exponential backoff.
   INTERNAL_SERVER_EXCEPTION = 3;
+
+  // NO_SUCH_KEY_EXCEPTION is used when the specified `key` in a `GetObjectRequest` does not exist.
+  NO_SUCH_KEY_EXCEPTION = 4;
 }
 
 // Represents a key-value pair to be stored or retrieved.

--- a/app/src/test/java/org/vss/api/GetObjectApiTest.java
+++ b/app/src/test/java/org/vss/api/GetObjectApiTest.java
@@ -16,6 +16,7 @@ import org.vss.GetObjectResponse;
 import org.vss.KVStore;
 import org.vss.KeyValue;
 import org.vss.exception.ConflictException;
+import org.vss.exception.NoSuchKeyException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -80,6 +81,7 @@ class GetObjectApiTest {
     return Stream.of(
         Arguments.of(new ConflictException(""), ErrorCode.CONFLICT_EXCEPTION),
         Arguments.of(new IllegalArgumentException(""), ErrorCode.INVALID_REQUEST_EXCEPTION),
+        Arguments.of(new NoSuchKeyException(""), ErrorCode.NO_SUCH_KEY_EXCEPTION),
         Arguments.of(new RuntimeException(""), ErrorCode.INTERNAL_SERVER_EXCEPTION)
     );
   }


### PR DESCRIPTION
Naming for error code matches aws s3 and gcp object store, seems like popular enough convention. 

Even though there are some popular KVStore's which do not throw such exception on keyNotFound such as Aws-DDB (arguably the most popular one), we can still figure out that key didn't exist if value was returned as null or by similar means in other stores. 

Motivation: Such checks are best performed in backend than having client checking empty or null value.
This is also in-line with more critical requirement for functioning of NotFound introduced by MonitorUpdatingPersister Design.