### PR TITLE
Allow Longer keys upto 600 chars

### DIFF
--- a/app/src/main/java/org/vss/impl/postgres/sql/v0_create_vss_db.sql
+++ b/app/src/main/java/org/vss/impl/postgres/sql/v0_create_vss_db.sql
@@ -1,6 +1,6 @@
 CREATE TABLE vss_db (
     store_id character varying(120) NOT NULL CHECK (store_id <> ''),
-    key character varying(120) NOT NULL,
+    key character varying(600) NOT NULL,
     value bytea NULL,
     version bigint NOT NULL,
     PRIMARY KEY (store_id, key)


### PR DESCRIPTION
Motivation: Earlier we were conservative about our key-size since it is easier to increase but difficult to increase in backward compatible fashion. Now with introduction of sub_namespace and directly allowing upto 360char keys in LDK, we need support for longer key lengths.

Earlier it was 120 based on uuid length.
