### PR TITLE
Add support for pluggable Authorizer, default to NoopAuthorizer

### DIFF
--- a/app/src/main/java/org/vss/KVStore.java
+++ b/app/src/main/java/org/vss/KVStore.java
@@ -4,11 +4,11 @@ public interface KVStore {
 
   String GLOBAL_VERSION_KEY = "vss_global_version";
 
-  GetObjectResponse get(GetObjectRequest request);
+  GetObjectResponse get(String userToken, GetObjectRequest request);
 
-  PutObjectResponse put(PutObjectRequest request);
+  PutObjectResponse put(String userToken, PutObjectRequest request);
 
-  DeleteObjectResponse delete(DeleteObjectRequest request);
+  DeleteObjectResponse delete(String userToken, DeleteObjectRequest request);
 
-  ListKeyVersionsResponse listKeyVersions(ListKeyVersionsRequest request);
+  ListKeyVersionsResponse listKeyVersions(String userToken, ListKeyVersionsRequest request);
 }

--- a/app/src/main/java/org/vss/api/AbstractVssApi.java
+++ b/app/src/main/java/org/vss/api/AbstractVssApi.java
@@ -7,16 +7,19 @@ import jakarta.ws.rs.core.Response;
 import org.vss.ErrorCode;
 import org.vss.ErrorResponse;
 import org.vss.KVStore;
+import org.vss.auth.Authorizer;
 import org.vss.exception.AuthException;
 import org.vss.exception.ConflictException;
 import org.vss.exception.NoSuchKeyException;
 
 public abstract class AbstractVssApi {
   final KVStore kvStore;
+  final Authorizer authorizer;
 
   @Inject
-  public AbstractVssApi(KVStore kvStore) {
+  public AbstractVssApi(KVStore kvStore, Authorizer authorizer) {
     this.kvStore = kvStore;
+    this.authorizer = authorizer;
   }
 
   Response toResponse(GeneratedMessageV3 protoResponse) {

--- a/app/src/main/java/org/vss/api/DeleteObjectApi.java
+++ b/app/src/main/java/org/vss/api/DeleteObjectApi.java
@@ -4,27 +4,32 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import lombok.extern.slf4j.Slf4j;
 import org.vss.DeleteObjectRequest;
 import org.vss.DeleteObjectResponse;
 import org.vss.KVStore;
+import org.vss.auth.AuthResponse;
+import org.vss.auth.Authorizer;
 
 @Path(VssApiEndpoint.DELETE_OBJECT)
 @Slf4j
 public class DeleteObjectApi extends AbstractVssApi {
   @Inject
-  public DeleteObjectApi(KVStore kvstore) {
-    super(kvstore);
+  public DeleteObjectApi(KVStore kvstore, Authorizer authorizer) {
+    super(kvstore, authorizer);
   }
 
   @POST
   @Produces(MediaType.APPLICATION_OCTET_STREAM)
-  public Response execute(byte[] payload) {
+  public Response execute(byte[] payload, @Context HttpHeaders headers) {
     try {
+      AuthResponse authResponse = authorizer.verify(headers);
       DeleteObjectRequest request = DeleteObjectRequest.parseFrom(payload);
-      DeleteObjectResponse response = kvStore.delete(request);
+      DeleteObjectResponse response = kvStore.delete(authResponse.getUserToken(), request);
       return toResponse(response);
     } catch (Exception e) {
       log.error("Exception in DeleteObjectApi: ", e);

--- a/app/src/main/java/org/vss/api/GetObjectApi.java
+++ b/app/src/main/java/org/vss/api/GetObjectApi.java
@@ -4,28 +4,33 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import lombok.extern.slf4j.Slf4j;
 import org.vss.GetObjectRequest;
 import org.vss.GetObjectResponse;
 import org.vss.KVStore;
+import org.vss.auth.AuthResponse;
+import org.vss.auth.Authorizer;
 
 @Path(VssApiEndpoint.GET_OBJECT)
 @Slf4j
 public class GetObjectApi extends AbstractVssApi {
 
   @Inject
-  public GetObjectApi(KVStore kvstore) {
-    super(kvstore);
+  public GetObjectApi(KVStore kvstore, Authorizer authorizer) {
+    super(kvstore, authorizer);
   }
 
   @POST
   @Produces(MediaType.APPLICATION_OCTET_STREAM)
-  public Response execute(byte[] payload) {
+  public Response execute(byte[] payload, @Context HttpHeaders headers) {
     try {
+      AuthResponse authResponse = authorizer.verify(headers);
       GetObjectRequest request = GetObjectRequest.parseFrom(payload);
-      GetObjectResponse response = kvStore.get(request);
+      GetObjectResponse response = kvStore.get(authResponse.getUserToken(), request);
       return toResponse(response);
     } catch (Exception e) {
       log.error("Exception in GetObjectApi: ", e);

--- a/app/src/main/java/org/vss/api/ListKeyVersionsApi.java
+++ b/app/src/main/java/org/vss/api/ListKeyVersionsApi.java
@@ -4,28 +4,33 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import lombok.extern.slf4j.Slf4j;
 import org.vss.KVStore;
 import org.vss.ListKeyVersionsRequest;
 import org.vss.ListKeyVersionsResponse;
+import org.vss.auth.AuthResponse;
+import org.vss.auth.Authorizer;
 
 @Path(VssApiEndpoint.LIST_KEY_VERSIONS)
 @Slf4j
 public class ListKeyVersionsApi extends AbstractVssApi {
 
   @Inject
-  public ListKeyVersionsApi(KVStore kvStore) {
-    super(kvStore);
+  public ListKeyVersionsApi(KVStore kvStore, Authorizer authorizer) {
+    super(kvStore, authorizer);
   }
 
   @POST
   @Produces(MediaType.APPLICATION_OCTET_STREAM)
-  public Response execute(byte[] payload) {
+  public Response execute(byte[] payload, @Context HttpHeaders headers) {
     try {
+      AuthResponse authResponse = authorizer.verify(headers);
       ListKeyVersionsRequest request = ListKeyVersionsRequest.parseFrom(payload);
-      ListKeyVersionsResponse response = kvStore.listKeyVersions(request);
+      ListKeyVersionsResponse response = kvStore.listKeyVersions(authResponse.getUserToken(), request);
       return toResponse(response);
     } catch (Exception e) {
       log.error("Exception in ListKeyVersionsApi: ", e);

--- a/app/src/main/java/org/vss/api/PutObjectsApi.java
+++ b/app/src/main/java/org/vss/api/PutObjectsApi.java
@@ -4,28 +4,33 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import lombok.extern.slf4j.Slf4j;
 import org.vss.KVStore;
 import org.vss.PutObjectRequest;
 import org.vss.PutObjectResponse;
+import org.vss.auth.AuthResponse;
+import org.vss.auth.Authorizer;
 
 @Path(VssApiEndpoint.PUT_OBJECTS)
 @Slf4j
 public class PutObjectsApi extends AbstractVssApi {
 
   @Inject
-  public PutObjectsApi(KVStore kvStore) {
-    super(kvStore);
+  public PutObjectsApi(KVStore kvStore, Authorizer authorizer) {
+    super(kvStore, authorizer);
   }
 
   @POST
   @Produces(MediaType.APPLICATION_OCTET_STREAM)
-  public Response execute(byte[] payload) {
+  public Response execute(byte[] payload, @Context HttpHeaders headers) {
     try {
+      AuthResponse authResponse = authorizer.verify(headers);
       PutObjectRequest putObjectRequest = PutObjectRequest.parseFrom(payload);
-      PutObjectResponse response = kvStore.put(putObjectRequest);
+      PutObjectResponse response = kvStore.put(authResponse.getUserToken(), putObjectRequest);
       return toResponse(response);
     } catch (Exception e) {
       log.error("Exception in PutObjectsApi: ", e);

--- a/app/src/main/java/org/vss/auth/AuthResponse.java
+++ b/app/src/main/java/org/vss/auth/AuthResponse.java
@@ -1,0 +1,10 @@
+package org.vss.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class AuthResponse {
+    private String userToken;
+}

--- a/app/src/main/java/org/vss/auth/Authorizer.java
+++ b/app/src/main/java/org/vss/auth/Authorizer.java
@@ -1,0 +1,9 @@
+package org.vss.auth;
+
+import jakarta.ws.rs.core.HttpHeaders;
+import org.vss.exception.AuthException;
+
+// Interface for authorizer that is run before every request.
+public interface Authorizer {
+    AuthResponse verify(HttpHeaders headers) throws AuthException;
+}

--- a/app/src/main/java/org/vss/auth/NoopAuthorizer.java
+++ b/app/src/main/java/org/vss/auth/NoopAuthorizer.java
@@ -1,0 +1,14 @@
+package org.vss.auth;
+
+import jakarta.ws.rs.core.HttpHeaders;
+import org.vss.exception.AuthException;
+
+// A no-operation authorizer, that lets any user-request go through.
+public class NoopAuthorizer implements Authorizer {
+    private static String UNAUTHENTICATED_USER = "unauth-user";
+
+    @Override
+    public AuthResponse verify(HttpHeaders headers) throws AuthException {
+        return new AuthResponse(UNAUTHENTICATED_USER);
+    }
+}

--- a/app/src/main/java/org/vss/guice/BaseModule.java
+++ b/app/src/main/java/org/vss/guice/BaseModule.java
@@ -11,7 +11,10 @@ import java.util.Properties;
 import org.jooq.DSLContext;
 import org.jooq.SQLDialect;
 import org.jooq.impl.DSL;
+import org.jooq.tools.StringUtils;
 import org.vss.KVStore;
+import org.vss.auth.Authorizer;
+import org.vss.auth.NoopAuthorizer;
 import org.vss.impl.postgres.PostgresBackendImpl;
 
 public class BaseModule extends AbstractModule {
@@ -20,6 +23,9 @@ public class BaseModule extends AbstractModule {
   protected void configure() {
     // Provide PostgresBackend as default implementation for KVStore.
     bind(KVStore.class).to(PostgresBackendImpl.class).in(Singleton.class);
+
+    // Default to Noop Authorizer.
+    bind(Authorizer.class).to(NoopAuthorizer.class).in(Singleton.class);
   }
 
   @Provides

--- a/app/src/main/java/org/vss/impl/postgres/sql/v0_create_vss_db.sql
+++ b/app/src/main/java/org/vss/impl/postgres/sql/v0_create_vss_db.sql
@@ -1,9 +1,10 @@
 CREATE TABLE vss_db (
+    user_token character varying(120) NOT NULL CHECK (user_token <> ''),
     store_id character varying(120) NOT NULL CHECK (store_id <> ''),
     key character varying(600) NOT NULL,
     value bytea NULL,
     version bigint NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE,
     last_updated_at TIMESTAMP WITH TIME ZONE,
-    PRIMARY KEY (store_id, key)
+    PRIMARY KEY (user_token, store_id, key)
 );

--- a/app/src/test/java/org/vss/AbstractKVStoreIntegrationTest.java
+++ b/app/src/test/java/org/vss/AbstractKVStoreIntegrationTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public abstract class AbstractKVStoreIntegrationTest {
 
+  private final String USER_TOKEN = "userToken";
   private final String STORE_ID = "storeId";
 
   protected KVStore kvStore;
@@ -426,7 +427,7 @@ public abstract class AbstractKVStoreIntegrationTest {
         .setStoreId(STORE_ID)
         .setKey(key)
         .build();
-    return this.kvStore.get(getRequest).getValue();
+    return this.kvStore.get(USER_TOKEN, getRequest).getValue();
   }
 
   private void putObjects(@Nullable Long globalVersion, List<KeyValue> keyValues) {
@@ -438,7 +439,7 @@ public abstract class AbstractKVStoreIntegrationTest {
       putObjectRequestBuilder.setGlobalVersion(globalVersion);
     }
 
-    this.kvStore.put(putObjectRequestBuilder.build());
+    this.kvStore.put(USER_TOKEN, putObjectRequestBuilder.build());
   }
 
   private void putAndDeleteObjects(@Nullable Long globalVersion, List<KeyValue> putKeyValues, List<KeyValue> deleteKeyValues) {
@@ -451,13 +452,13 @@ public abstract class AbstractKVStoreIntegrationTest {
       putObjectRequestBuilder.setGlobalVersion(globalVersion);
     }
 
-    this.kvStore.put(putObjectRequestBuilder.build());
+    this.kvStore.put(USER_TOKEN, putObjectRequestBuilder.build());
   }
 
   private void deleteObject(KeyValue keyValue) {
     DeleteObjectRequest request = DeleteObjectRequest.newBuilder()
         .setStoreId(STORE_ID).setKeyValue(keyValue).build();
-    this.kvStore.delete(request);
+    this.kvStore.delete(USER_TOKEN, request);
   }
 
   private ListKeyVersionsResponse list(@Nullable String nextPageToken, @Nullable Integer pageSize,
@@ -475,7 +476,7 @@ public abstract class AbstractKVStoreIntegrationTest {
       listRequestBuilder.setKeyPrefix(keyPrefix);
     }
 
-    return this.kvStore.listKeyVersions(listRequestBuilder.build());
+    return this.kvStore.listKeyVersions(USER_TOKEN, listRequestBuilder.build());
   }
 
   private KeyValue kv(String key, String value, int version) {

--- a/app/src/test/java/org/vss/api/PutObjectsApiTest.java
+++ b/app/src/test/java/org/vss/api/PutObjectsApiTest.java
@@ -1,6 +1,7 @@
 package org.vss.api;
 
 import com.google.protobuf.ByteString;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -16,6 +17,8 @@ import org.vss.KVStore;
 import org.vss.KeyValue;
 import org.vss.PutObjectRequest;
 import org.vss.PutObjectResponse;
+import org.vss.auth.AuthResponse;
+import org.vss.auth.Authorizer;
 import org.vss.exception.ConflictException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -28,7 +31,10 @@ import static org.mockito.Mockito.when;
 public class PutObjectsApiTest {
   private PutObjectsApi putObjectsApi;
   private KVStore mockKVStore;
+  private Authorizer mockAuthorizer;
+  private HttpHeaders mockHeaders;
 
+  private static String TEST_USER_TOKEN = "userToken";
   private static String TEST_STORE_ID = "storeId";
   private static String TEST_KEY = "key";
   private static KeyValue TEST_KV = KeyValue.newBuilder().setKey(TEST_KEY).setValue(
@@ -37,7 +43,10 @@ public class PutObjectsApiTest {
   @BeforeEach
   void setUp() {
     mockKVStore = mock(KVStore.class);
-    putObjectsApi = new PutObjectsApi(mockKVStore);
+    mockAuthorizer = mock(Authorizer.class);
+    putObjectsApi = new PutObjectsApi(mockKVStore, mockAuthorizer);
+    mockHeaders = mock(HttpHeaders.class);
+    when(mockAuthorizer.verify(any())).thenReturn(new AuthResponse(TEST_USER_TOKEN));
   }
 
   @Test
@@ -49,13 +58,13 @@ public class PutObjectsApiTest {
             .build();
     byte[] payload = expectedRequest.toByteArray();
     PutObjectResponse mockResponse = PutObjectResponse.newBuilder().build();
-    when(mockKVStore.put(expectedRequest)).thenReturn(mockResponse);
+    when(mockKVStore.put(TEST_USER_TOKEN, expectedRequest)).thenReturn(mockResponse);
 
-    Response actualResponse = putObjectsApi.execute(payload);
+    Response actualResponse = putObjectsApi.execute(payload, mockHeaders);
 
     assertThat(actualResponse.getStatus(), is(Response.Status.OK.getStatusCode()));
     assertThat(actualResponse.getEntity(), is(mockResponse.toByteArray()));
-    verify(mockKVStore).put(expectedRequest);
+    verify(mockKVStore).put(TEST_USER_TOKEN, expectedRequest);
   }
 
   @ParameterizedTest
@@ -68,9 +77,9 @@ public class PutObjectsApiTest {
             .addAllTransactionItems(List.of(TEST_KV))
             .build();
     byte[] payload = expectedRequest.toByteArray();
-    when(mockKVStore.put(any())).thenThrow(exception);
+    when(mockKVStore.put(any(), any())).thenThrow(exception);
 
-    Response response = putObjectsApi.execute(payload);
+    Response response = putObjectsApi.execute(payload, mockHeaders);
 
     ErrorResponse expectedErrorResponse = ErrorResponse.newBuilder()
         .setErrorCode(errorCode)
@@ -78,7 +87,7 @@ public class PutObjectsApiTest {
         .build();
     assertThat(response.getEntity(), is(expectedErrorResponse.toByteArray()));
     assertThat(response.getStatus(), is(statusCode));
-    verify(mockKVStore).put(expectedRequest);
+    verify(mockKVStore).put(TEST_USER_TOKEN, expectedRequest);
   }
 
   private static Stream<Arguments> provideErrorTestCases() {

--- a/app/src/test/java/org/vss/impl/postgres/PostgresBackendImplIntegrationTest.java
+++ b/app/src/test/java/org/vss/impl/postgres/PostgresBackendImplIntegrationTest.java
@@ -46,14 +46,15 @@ public class PostgresBackendImplIntegrationTest extends AbstractKVStoreIntegrati
   }
 
   private void createTable(DSLContext dslContext) {
-    dslContext.execute("CREATE TABLE vss_db ("
-        + "store_id character varying(120) NOT NULL CHECK (store_id <> ''),"
-        + "key character varying(600) NOT NULL,"
-        + "value bytea NULL,"
-        + "version bigint NOT NULL,"
-        + "created_at TIMESTAMP WITH TIME ZONE,"
-        + "last_updated_at TIMESTAMP WITH TIME ZONE,"
-        + "PRIMARY KEY (store_id, key)"
-        + ");");
+    dslContext.execute("CREATE TABLE vss_db (" +
+        "user_token character varying(120) NOT NULL CHECK (user_token <> '')," +
+        "store_id character varying(120) NOT NULL CHECK (store_id <> '')," +
+        "key character varying(600) NOT NULL," +
+        "value bytea NULL," +
+        "version bigint NOT NULL," +
+        "created_at TIMESTAMP WITH TIME ZONE," +
+        "last_updated_at TIMESTAMP WITH TIME ZONE," +
+        "PRIMARY KEY (user_token, store_id, key)" +
+        ");");
   }
 }


### PR DESCRIPTION
* Add support for pluggable Authorizer, default to NoopAuthorizer

Different authorizers can act upon headers to return userToken or throw AuthException if auth fails.

We can later implement `JWTAuthorizer` or others.

If hosting providers, want to supply some other variant or add additional checks, they can just implement this interface.

Based on #30.