### PR TITLE
Add log4j as Slf4j Impl.

### DIFF
--- a/java/app/build.gradle
+++ b/java/app/build.gradle
@@ -62,6 +62,8 @@ dependencies {
 
   compileOnly 'org.projectlombok:lombok:1.18.24'
   annotationProcessor 'org.projectlombok:lombok:1.18.24'
+  implementation "org.slf4j:slf4j-api:1.7.36"
+  runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.24.2'
 
   testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
   testImplementation "org.junit.jupiter:junit-jupiter-params:$junitVersion"


### PR DESCRIPTION
Since SLF4J is only a logging facade and does not
provide a concrete logging implementation, we need to include `log4j-slf4j-impl` as a dependency.
This allows SLF4J to route logging calls to Log4j-2, which acts as the backend logging framework.

Related: https://discord.com/channels/915026692102316113/1184952845720617012/1316310889951002634

Tested this with local docker run. 
Earlier i was getting error `SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".`

After the fix i could see "ERROR org.vss.api.PutObjectsApi - Exception in PutObjectsApi: 
2024-12-11 14:56:22 com.google.protobuf.InvalidProtocolBufferException: While parsing a protocol message," on incorrect message.