### PR TITLE
build: upgrade jooq and add junit platform

### DIFF
--- a/.github/workflows/build-and-deploy-java.yml
+++ b/.github/workflows/build-and-deploy-java.yml
@@ -54,10 +54,15 @@ jobs:
         run: |
           # Print Info
           java -version
-          gradle --version
+          GRADLE_VERSION=$(gradle --version | awk '/^Gradle/ {print $2}' | head -1)
+          if [ -z "$GRADLE_VERSION" ]; then
+            echo "Failed to extract Gradle version, using default"
+            GRADLE_VERSION="9.0"
+          fi
+          echo "Gradle $GRADLE_VERSION"
 
           cd java
-          gradle wrapper --gradle-version 8.1.1
+          gradle wrapper --gradle-version $GRADLE_VERSION
           ./gradlew --version
           ./gradlew build
 

--- a/java/app/build.gradle
+++ b/java/app/build.gradle
@@ -5,7 +5,7 @@ buildscript {
   ext.junitVersion = '5.9.0'
   ext.mockitoVersion = '5.2.0'
   ext.postgresVersion = '42.5.1'
-  ext.jooqVersion = '3.17.7'
+  ext.jooqVersion = '3.19.1'
   ext.guiceVersion = '5.1.0'
 }
 
@@ -14,7 +14,7 @@ plugins {
   id 'com.google.protobuf' version "${protobufPlugInVersion}"
   id 'war'
   id 'idea'
-  id 'nu.studer.jooq' version '8.0'
+  id 'nu.studer.jooq' version '8.2.2'
 }
 
 repositories {

--- a/java/app/build.gradle
+++ b/java/app/build.gradle
@@ -69,6 +69,7 @@ dependencies {
   testImplementation "org.junit.jupiter:junit-jupiter-params:$junitVersion"
   testImplementation "org.mockito:mockito-core:$mockitoVersion"
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
+  testRuntimeOnly "org.junit.platform:junit-platform-launcher:1.9.0"
   testImplementation "org.hamcrest:hamcrest-library:2.2"
   testImplementation "org.testcontainers:junit-jupiter:1.17.6"
   testImplementation "org.testcontainers:postgresql:1.17.6"


### PR DESCRIPTION
## What this PR does
With the release of Gradle `9.0.0`, we experienced build
failures due to deprecated access to plugin conventions
(JavaPluginConvention).
Ref: [Gradle `9.0` release]( https://docs.gradle.org/9.0.0-rc-1/userguide/upgrading_version_8.html#deprecated_access_to_conventions)

To address this, we:
- Upgrade jOOQ Gradle plugin from `8.0` to `8.2.2` to
avoid deprecation warnings when using Gradle `9.0`.
Ref: [jOOQ plugin release](https://github.com/etiennestuder/gradle-jooq-plugin/releases/tag/v8.2.2)
- Upgrade jOOQ from `3.17.7` to `3.19.1` to match the
plugin version upgrade.

Note: We avoid the latest version of jOOQ because it
requires Java 21.

Additionally, we add JUnit Platform Launcher which
is required for JUnit 5 tests in newer Gradle versions.

## Related Issues
- LDK-Node Issue [#581](https://github.com/lightningdevkit/ldk-node/issues/581)

cc @tnull
