### PR TITLE
Return appropriate HTTP status codes in error responses

### DIFF
--- a/rust/server/src/vss_service.rs
+++ b/rust/server/src/vss_service.rs
@@ -162,7 +162,7 @@ fn build_error_response(e: VssError) -> Response<Full<Bytes>> {
 			};
 			(status, error)
 		},
-		_ => {
+		VssError::InternalServerError(_) => {
 			let status = StatusCode::INTERNAL_SERVER_ERROR;
 			let error = ErrorResponse {
 				error_code: ErrorCode::InternalServerException.into(),


### PR DESCRIPTION
In the deprecated Java version, we used to use appropriate HTTP status codes (400/409/etc): https://github.com/lightningdevkit/vss-server/blob/16874ec0638a2defc93d192508c8b962abc26926/java/app/src/main/java/org/vss/api/AbstractVssApi.java#L33-L52

However, in the Rust server we currently always return 500 / `INTERNAL_SERVER_ERROR. Here we fix this oversight.