### PR TITLE
Add 60 min timeout to ldk-node-integration CI

### DIFF
--- a/.github/workflows/ldk-node-integration.yml
+++ b/.github/workflows/ldk-node-integration.yml
@@ -14,6 +14,7 @@ jobs:
         platform: [ ubuntu-latest ]
         toolchain: [ stable, 1.85.0 ] # 1.85.0 is the MSRV
     runs-on: ${{ matrix.platform }}
+    timeout-minutes: 60
 
     services:
       postgres:


### PR DESCRIPTION
This job ran for 6 hours in #96, should have a timeout to prevent this