### PR TITLE
Add health check API endpoint

### DIFF
--- a/.github/workflows/build-and-deploy-rust.yml
+++ b/.github/workflows/build-and-deploy-rust.yml
@@ -45,6 +45,9 @@ jobs:
         run: |
           sleep 5
 
+          # Health check
+          curl -f http://localhost:8080/vss/health
+
           # Put request with store='storeId' and key=k1
           hex=0A0773746F726549641A150A026B3110FFFFFFFFFFFFFFFFFF011A046B317631
           curl -f --data-binary "$(echo "$hex" | xxd -r -p)" http://localhost:8080/vss/putObjects

--- a/proto/vss.proto
+++ b/proto/vss.proto
@@ -245,6 +245,22 @@ message ListKeyVersionsResponse {
   optional int64 global_version = 3;
 }
 
+// Request payload to be used for `HealthCheck` API call to server.
+// Clients can call this API to verify that the server is running and to query
+// the version of the VSS protocol supported by the server.
+// This API is unauthenticated.
+message HealthCheckRequest {
+}
+
+// Server response for `HealthCheck` API.
+// A successful HTTP 200 response indicates that the VSS server is operational.
+message HealthCheckResponse {
+
+  // The version of the VSS protocol supported by this server.
+  // Clients can use this to verify protocol compatibility with the server.
+  int64 version = 1;
+}
+
 // When HttpStatusCode is not ok (200), the response `content` contains a serialized `ErrorResponse`
 // with the relevant `ErrorCode` and `message`
 message ErrorResponse {

--- a/rust/api/src/lib.rs
+++ b/rust/api/src/lib.rs
@@ -9,6 +9,10 @@
 #![deny(rustdoc::private_intra_doc_links)]
 #![deny(missing_docs)]
 
+/// The version of the VSS protocol supported by this implementation.
+/// Returned to clients via the `HealthCheck` API for protocol compatibility checks.
+pub const VSS_PROTOCOL_VERSION: i64 = 1;
+
 /// Contains interface for authorizer that is run before every request, and its corresponding implementations.
 pub mod auth;
 /// Implements the error type ([`error::VssError`]) which is eventually converted to [`ErrorResponse`] and returned to the client.

--- a/rust/api/src/types.rs
+++ b/rust/api/src/types.rs
@@ -247,6 +247,23 @@ pub struct ListKeyVersionsResponse {
 	#[prost(int64, optional, tag = "3")]
 	pub global_version: ::core::option::Option<i64>,
 }
+/// Request payload to be used for `HealthCheck` API call to server.
+/// Clients can call this API to verify that the server is running and to query
+/// the version of the VSS protocol supported by the server.
+/// This API is unauthenticated.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HealthCheckRequest {}
+/// Server response for `HealthCheck` API.
+/// A successful HTTP 200 response indicates that the VSS server is operational.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HealthCheckResponse {
+	/// The version of the VSS protocol supported by this server.
+	/// Clients can use this to verify protocol compatibility with the server.
+	#[prost(int64, tag = "1")]
+	pub version: i64,
+}
 /// When HttpStatusCode is not ok (200), the response `content` contains a serialized `ErrorResponse`
 /// with the relevant `ErrorCode` and `message`
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/rust/server/src/vss_service.rs
+++ b/rust/server/src/vss_service.rs
@@ -80,6 +80,10 @@ impl Service<Request<Incoming>> for VssService {
 			let prefix_stripped_path = path.strip_prefix(BASE_PATH_PREFIX).unwrap_or_default();
 
 			match prefix_stripped_path {
+				"/health" => Ok(Response::builder()
+					.status(StatusCode::OK)
+					.body(Full::new(Bytes::new()))
+					.unwrap()),
 				"/getObject" => {
 					handle_request(
 						store,

--- a/rust/server/src/vss_service.rs
+++ b/rust/server/src/vss_service.rs
@@ -11,9 +11,10 @@ use api::error::VssError;
 use api::kv_store::KvStore;
 use api::types::{
 	DeleteObjectRequest, DeleteObjectResponse, ErrorCode, ErrorResponse, GetObjectRequest,
-	GetObjectResponse, ListKeyVersionsRequest, ListKeyVersionsResponse, PutObjectRequest,
-	PutObjectResponse,
+	GetObjectResponse, HealthCheckResponse, ListKeyVersionsRequest, ListKeyVersionsResponse,
+	PutObjectRequest, PutObjectResponse,
 };
+use api::VSS_PROTOCOL_VERSION;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -80,10 +81,13 @@ impl Service<Request<Incoming>> for VssService {
 			let prefix_stripped_path = path.strip_prefix(BASE_PATH_PREFIX).unwrap_or_default();
 
 			match prefix_stripped_path {
-				"/health" => Ok(Response::builder()
-					.status(StatusCode::OK)
-					.body(Full::new(Bytes::new()))
-					.unwrap()),
+				"/health" => {
+					let response = HealthCheckResponse { version: VSS_PROTOCOL_VERSION };
+					Ok(Response::builder()
+						.status(StatusCode::OK)
+						.body(Full::new(Bytes::from(response.encode_to_vec())))
+						.unwrap())
+				},
 				"/getObject" => {
 					handle_request(
 						store,


### PR DESCRIPTION
Adds an unauthenticated `GET /vss/health` endpoint that returns `HTTP 200` with an empty body, so load balancers and monitoring tools can verify the server is running without making actual storage requests.

Also adds a health check `curl` step to the Ping Check CI workflow.

Closes #29